### PR TITLE
authprogs/authprogs.py: use os.path.expanduser instead of os.environ['HO...

### DIFF
--- a/authprogs/authprogs.py
+++ b/authprogs/authprogs.py
@@ -474,7 +474,7 @@ def main():  # pylint: disable-msg=R0912,R0915
                      help='Write additional debugging information '
                      'to --logfile')
     group.add_option('--authorized_keys', dest='authorized_keys',
-                     default=os.path.join(os.environ['HOME'],
+                     default=os.path.join(os.path.expanduser('~'),
                                           '.ssh', 'authorized_keys'),
                      help='Location of authorized_keys file for '
                      '--install_key. Defaults to ~/.ssh/authorized_keys',
@@ -486,11 +486,11 @@ def main():  # pylint: disable-msg=R0912,R0915
         sys.exit('authprogs does not accept commandline arguments.')
 
     if not opts.configfile:
-        cfg = os.path.join(os.environ['HOME'], '.ssh', 'authprogs.yaml')
+        cfg = os.path.join(os.path.expanduser('~'), '.ssh', 'authprogs.yaml')
         if os.path.isfile(cfg):
             opts.configfile = cfg
     if not opts.configdir:
-        cfg = os.path.join(os.environ['HOME'], '.ssh', 'authprogs.d')
+        cfg = os.path.join(os.path.expanduser('~'), '.ssh', 'authprogs.d')
         if os.path.isdir(cfg):
             opts.configdir = cfg
 

--- a/doc/authprogs.md
+++ b/doc/authprogs.md
@@ -228,7 +228,7 @@ The general format of a rule is as follows:
 
     # Next rule begins here
     selection_option_3: value
-    ...
+    \[char46]..
 
 Some of the keys take single arguments, while others may take lists.
 See the definition of each to understand the values it accepts.

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ class Converter(object):
 
             target = open(htmlfile, 'w')
             self.created.append(htmlfile)
-            stdout = runcmd(['markdown', os.path.join(top, '%s.md' % name)])[1]
+            stdout = runcmd(['markdown', os.path.join(doc, '%s.md' % name)])[1]
             if not stdout:
                 raise Exception('markdown conversion failed, no output.')
             target.write(stdout)
@@ -140,7 +140,7 @@ setup(
     data_files=[
         ('share/man/man1/', ['doc/authprogs.1']),
         ('share/doc/authprogs/',
-         ['AUTHORS', 'COPYING', 'INSTALL', 'README',
+         ['AUTHORS','README',
           'TODO', 'doc/authprogs.html'])],
     test_suite='authprogs.tests',
     install_requires=['pyyaml'],


### PR DESCRIPTION
...ME'].

 The former falls back on the user's home dir from
 the password database when HOME is unset.
doc/authprogs.md: fixing "manpage-has-errors-from-man usr/share/man/man1/authprogs.1.gz
 275: warning: macro `..' not defined" by replacing '.' with [char46]
setup.py: fix doc/authprogs.html generation
